### PR TITLE
Fix code singing issue for a framework build with Xcode 8

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
+github "jspahrsummers/xcconfigs" "1ef97639ffbe041da0b1392b2114fa19b922a7a1"
 github "Quick/Quick" ~> 0.9.2
 github "Quick/Nimble" ~> 4.0.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v4.0.1"
 github "Quick/Quick" "v0.9.2"
-github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
+github "jspahrsummers/xcconfigs" "1ef97639ffbe041da0b1392b2114fa19b922a7a1"

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -1338,7 +1338,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 98AA74481BB70CBB00E2F48A /* Debug.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1358,7 +1357,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 98AA744A1BB70CBB00E2F48A /* Release.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;


### PR DESCRIPTION
Updated jspahrsummers/xcconfigs in Cartfile to fix code signing issue for a framework built with Xcode 8.
https://github.com/Swinject/Swinject/issues/120

Some code signing identity settings in the project were removed too to use the settings in xcconfigs.