### PR TITLE
Support Xcode 8 beta 6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "Carthage/Checkouts/Nimble"]
 	path = Carthage/Checkouts/Nimble
-	url = https://github.com/Quick/Nimble.git
+	url = https://github.com/ikesyo/Nimble.git
 [submodule "Carthage/Checkouts/Quick"]
 	path = Carthage/Checkouts/Quick
-	url = https://github.com/Quick/Quick.git
+	url = https://github.com/ikesyo/Quick.git
 [submodule "Carthage/Checkouts/xcconfigs"]
 	path = Carthage/Checkouts/xcconfigs
 	url = https://github.com/jspahrsummers/xcconfigs.git

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" "1ef97639ffbe041da0b1392b2114fa19b922a7a1"
-github "Quick/Quick" ~> 0.9.2
-github "Quick/Nimble" ~> 4.0.1
+github "ikesyo/Quick" "17aae699bd8b035688fa7e176e383ea9d2a335ea"
+github "ikesyo/Nimble" "4caecb3cef0c9a2973c598b99e1495009faf57b1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v4.0.1"
-github "Quick/Quick" "v0.9.2"
+github "Quick/Nimble" "v4.1.0"
+github "Quick/Quick" "v0.9.3"
 github "jspahrsummers/xcconfigs" "1ef97639ffbe041da0b1392b2114fa19b922a7a1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v4.1.0"
-github "Quick/Quick" "v0.9.3"
+github "ikesyo/Nimble" "4caecb3cef0c9a2973c598b99e1495009faf57b1"
+github "ikesyo/Quick" "17aae699bd8b035688fa7e176e383ea9d2a335ea"
 github "jspahrsummers/xcconfigs" "1ef97639ffbe041da0b1392b2114fa19b922a7a1"

--- a/Sources/Container.Arguments.erb
+++ b/Sources/Container.Arguments.erb
@@ -35,6 +35,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
         name: String? = nil,

--- a/Sources/Container.Arguments.erb
+++ b/Sources/Container.Arguments.erb
@@ -36,7 +36,7 @@ extension Container {
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
     public func register<Service, <%= arg_types %>>(
-        serviceType: Service.Type,
+        _ serviceType: Service.Type,
         name: String? = nil,
         factory: (ResolverType, <%= arg_types %>) -> Service) -> ServiceEntry<Service>
     {
@@ -64,7 +64,7 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
     ///            and <%= arg_param_description %> is found in the `Container`.
     public func resolve<Service, <%= arg_types %>>(
-        serviceType: Service.Type,
+        _ serviceType: Service.Type,
         <%= arg_param_def %>) -> Service?
     {
         return resolve(serviceType, name: nil, <%= arg_param_name %>: <%= arg_param_call %>)
@@ -80,7 +80,7 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            <%= arg_param_description %> and name is found in the `Container`.
     public func resolve<Service, <%= arg_types %>>(
-        serviceType: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
         <%= arg_param_def %>) -> Service?
     {

--- a/Sources/Container.Arguments.swift
+++ b/Sources/Container.Arguments.swift
@@ -31,6 +31,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -51,6 +52,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -71,6 +73,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -91,6 +94,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -111,6 +115,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -131,6 +136,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -151,6 +157,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -171,6 +178,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -191,6 +199,7 @@ extension Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String? = nil,

--- a/Sources/Container.Arguments.swift
+++ b/Sources/Container.Arguments.swift
@@ -236,268 +236,268 @@ extension Container {
         return _resolve(name: name) { (factory: FactoryType) in factory(self, argument) }
     }
 
-    /// Retrieves the instance with the specified service type and tuple of 2 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 2 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 2 arguments is found in the `Container`.
+    ///            and list of 2 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
     {
-        return resolve(serviceType, name: nil, arguments: arguments)
+        return resolve(serviceType, name: nil, arguments: arg1, arg2)
     }
 
-    /// Retrieves the instance with the specified service type, tuple of 2 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 2 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 2 arguments and name is found in the `Container`.
+    ///            list of 2 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
     {
         typealias FactoryType = (ResolverType, Arg1, Arg2) -> Service
-        return _resolve(name: name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1) }
+        return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2) }
     }
 
-    /// Retrieves the instance with the specified service type and tuple of 3 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 3 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 3 arguments is found in the `Container`.
+    ///            and list of 3 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
     {
-        return resolve(serviceType, name: nil, arguments: arguments)
+        return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3)
     }
 
-    /// Retrieves the instance with the specified service type, tuple of 3 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 3 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 3 arguments and name is found in the `Container`.
+    ///            list of 3 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
     {
         typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3) -> Service
-        return _resolve(name: name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2) }
+        return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3) }
     }
 
-    /// Retrieves the instance with the specified service type and tuple of 4 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 4 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 4 arguments is found in the `Container`.
+    ///            and list of 4 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
     {
-        return resolve(serviceType, name: nil, arguments: arguments)
+        return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4)
     }
 
-    /// Retrieves the instance with the specified service type, tuple of 4 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 4 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 4 arguments and name is found in the `Container`.
+    ///            list of 4 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
     {
         typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4) -> Service
-        return _resolve(name: name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3) }
+        return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4) }
     }
 
-    /// Retrieves the instance with the specified service type and tuple of 5 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 5 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 5 arguments is found in the `Container`.
+    ///            and list of 5 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
     {
-        return resolve(serviceType, name: nil, arguments: arguments)
+        return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5)
     }
 
-    /// Retrieves the instance with the specified service type, tuple of 5 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 5 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 5 arguments and name is found in the `Container`.
+    ///            list of 5 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
     {
         typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
-        return _resolve(name: name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4) }
+        return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5) }
     }
 
-    /// Retrieves the instance with the specified service type and tuple of 6 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 6 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 6 arguments is found in the `Container`.
+    ///            and list of 6 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
     {
-        return resolve(serviceType, name: nil, arguments: arguments)
+        return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
     }
 
-    /// Retrieves the instance with the specified service type, tuple of 6 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 6 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 6 arguments and name is found in the `Container`.
+    ///            list of 6 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
     {
         typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
-        return _resolve(name: name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5) }
+        return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6) }
     }
 
-    /// Retrieves the instance with the specified service type and tuple of 7 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 7 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 7 arguments is found in the `Container`.
+    ///            and list of 7 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
     {
-        return resolve(serviceType, name: nil, arguments: arguments)
+        return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
     }
 
-    /// Retrieves the instance with the specified service type, tuple of 7 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 7 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 7 arguments and name is found in the `Container`.
+    ///            list of 7 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
     {
         typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
-        return _resolve(name: name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6) }
+        return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7) }
     }
 
-    /// Retrieves the instance with the specified service type and tuple of 8 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 8 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 8 arguments is found in the `Container`.
+    ///            and list of 8 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
     {
-        return resolve(serviceType, name: nil, arguments: arguments)
+        return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
     }
 
-    /// Retrieves the instance with the specified service type, tuple of 8 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 8 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 8 arguments and name is found in the `Container`.
+    ///            list of 8 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
     {
         typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
-        return _resolve(name: name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7) }
+        return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) }
     }
 
-    /// Retrieves the instance with the specified service type and tuple of 9 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 9 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 9 arguments is found in the `Container`.
+    ///            and list of 9 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
     {
-        return resolve(serviceType, name: nil, arguments: arguments)
+        return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
     }
 
-    /// Retrieves the instance with the specified service type, tuple of 9 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 9 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 9 arguments and name is found in the `Container`.
+    ///            list of 9 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
     {
         typealias FactoryType = (ResolverType, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
-        return _resolve(name: name) { (factory: FactoryType) in factory(self, arguments.0, arguments.1, arguments.2, arguments.3, arguments.4, arguments.5, arguments.6, arguments.7, arguments.8) }
+        return _resolve(name: name) { (factory: FactoryType) in factory(self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) }
     }
 
 }

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -64,6 +64,7 @@ public final class Container {
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func register<Service>(
         _ serviceType: Service.Type,
         name: String? = nil,
@@ -85,6 +86,7 @@ public final class Container {
     ///   - option:      A service key option for an extension/plugin.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
     public func _register<Service, Factory>(
         _ serviceType: Service.Type,
         factory: Factory,

--- a/Sources/ResolverType.erb
+++ b/Sources/ResolverType.erb
@@ -22,7 +22,7 @@ public protocol ResolverType {
     /// - Parameter serviceType: The service type to resolve.
     ///
     /// - Returns: The resolved service type instance, or nil if no service is found.
-    func resolve<Service>(serviceType: Service.Type) -> Service?
+    func resolve<Service>(_ serviceType: Service.Type) -> Service?
 
     /// Retrieves the instance with the specified service type and registration name.
     ///
@@ -31,7 +31,7 @@ public protocol ResolverType {
     ///   - name:        The registration name.
     ///
     /// - Returns: The resolved service type instance, or nil if no service with the name is found.
-    func resolve<Service>(serviceType: Service.Type, name: String?) -> Service?
+    func resolve<Service>(_ serviceType: Service.Type, name: String?) -> Service?
 
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
@@ -47,7 +47,7 @@ public protocol ResolverType {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
     ///            and <%= arg_param_description %> is found.
     func resolve<Service, <%= arg_types %>>(
-        serviceType: Service.Type,
+        _ serviceType: Service.Type,
         <%= arg_param %>) -> Service?
 
     /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.
@@ -60,7 +60,7 @@ public protocol ResolverType {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            <%= arg_param_description %> and name is found.
     func resolve<Service, <%= arg_types %>>(
-        serviceType: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
         <%= arg_param %>) -> Service?
 

--- a/Sources/ResolverType.swift
+++ b/Sources/ResolverType.swift
@@ -58,213 +58,213 @@ public protocol ResolverType {
         name: String?,
         argument: Arg1) -> Service?
 
-    /// Retrieves the instance with the specified service type and tuple of 2 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 2 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 2 arguments is found.
+    ///            and list of 2 arguments is found.
     func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
 
-    /// Retrieves the instance with the specified service type, tuple of 2 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 2 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 2 arguments to pass to the factory closure.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 2 arguments and name is found.
+    ///            list of 2 arguments and name is found.
     func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
 
-    /// Retrieves the instance with the specified service type and tuple of 3 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 3 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 3 arguments is found.
+    ///            and list of 3 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
 
-    /// Retrieves the instance with the specified service type, tuple of 3 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 3 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 3 arguments to pass to the factory closure.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 3 arguments and name is found.
+    ///            list of 3 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
 
-    /// Retrieves the instance with the specified service type and tuple of 4 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 4 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 4 arguments is found.
+    ///            and list of 4 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
 
-    /// Retrieves the instance with the specified service type, tuple of 4 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 4 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 4 arguments to pass to the factory closure.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 4 arguments and name is found.
+    ///            list of 4 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
 
-    /// Retrieves the instance with the specified service type and tuple of 5 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 5 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 5 arguments is found.
+    ///            and list of 5 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
 
-    /// Retrieves the instance with the specified service type, tuple of 5 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 5 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 5 arguments to pass to the factory closure.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 5 arguments and name is found.
+    ///            list of 5 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
 
-    /// Retrieves the instance with the specified service type and tuple of 6 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 6 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 6 arguments is found.
+    ///            and list of 6 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
 
-    /// Retrieves the instance with the specified service type, tuple of 6 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 6 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 6 arguments to pass to the factory closure.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 6 arguments and name is found.
+    ///            list of 6 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
 
-    /// Retrieves the instance with the specified service type and tuple of 7 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 7 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 7 arguments is found.
+    ///            and list of 7 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
 
-    /// Retrieves the instance with the specified service type, tuple of 7 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 7 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 7 arguments to pass to the factory closure.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 7 arguments and name is found.
+    ///            list of 7 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
 
-    /// Retrieves the instance with the specified service type and tuple of 8 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 8 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 8 arguments is found.
+    ///            and list of 8 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
 
-    /// Retrieves the instance with the specified service type, tuple of 8 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 8 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 8 arguments to pass to the factory closure.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 8 arguments and name is found.
+    ///            list of 8 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
 
-    /// Retrieves the instance with the specified service type and tuple of 9 arguments to the factory closure.
+    /// Retrieves the instance with the specified service type and list of 9 arguments to the factory closure.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
-    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and tuple of 9 arguments is found.
+    ///            and list of 9 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
 
-    /// Retrieves the instance with the specified service type, tuple of 9 arguments to the factory closure and registration name.
+    /// Retrieves the instance with the specified service type, list of 9 arguments to the factory closure and registration name.
     ///
     /// - Parameters:
     ///   - serviceType: The service type to resolve.
     ///   - name:        The registration name.
-    ///   - arguments:   Tuple of 9 arguments to pass to the factory closure.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            tuple of 9 arguments and name is found.
+    ///            list of 9 arguments and name is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
 
 
 }

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -16,7 +16,7 @@ internal protocol ServiceEntryType: Any {
 /// The `ServiceEntry<Service>` class represents an entry of a registered service type.
 /// As a returned instance from a `register` method of a `Container`, some configurations can be added.
 public final class ServiceEntry<Service> {
-    private let serviceType: Service.Type
+    fileprivate let serviceType: Service.Type
     internal let factory: FunctionType
 
     internal var objectScope = ObjectScope.graph
@@ -52,7 +52,7 @@ public final class ServiceEntry<Service> {
     /// - Parameter completed: The closure to be called after the instantiation of the registered service.
     ///
     /// - Returns: `self` to add another configuration fluently.
-    public func initCompleted(_ completed: (ResolverType, Service) -> ()) -> Self {
+    public func initCompleted(_ completed: @escaping (ResolverType, Service) -> ()) -> Self {
         initCompleted = completed
         return self
     }
@@ -67,7 +67,7 @@ extension ServiceEntry: ServiceEntryType {
         return "Service: \(serviceType)"
             + nameDescription
             + optionDescription
-            + ", Factory: \(factory.dynamicType)"
+            + ", Factory: \(type(of: factory))"
             + ", ObjectScope: \(objectScope)"
             + initCompletedDescription
     }

--- a/Sources/ServiceEntry.swift
+++ b/Sources/ServiceEntry.swift
@@ -40,6 +40,7 @@ public final class ServiceEntry<Service> {
     /// - Parameter scope: The `ObjectScope` value.
     ///
     /// - Returns: `self` to add another configuration fluently.
+    @discardableResult
     public func inObjectScope(_ objectScope: ObjectScope) -> Self {
         self.objectScope = objectScope
         return self
@@ -52,6 +53,7 @@ public final class ServiceEntry<Service> {
     /// - Parameter completed: The closure to be called after the instantiation of the registered service.
     ///
     /// - Returns: `self` to add another configuration fluently.
+    @discardableResult
     public func initCompleted(_ completed: @escaping (ResolverType, Service) -> ()) -> Self {
         initCompleted = completed
         return self

--- a/Sources/ServiceKey.swift
+++ b/Sources/ServiceKey.swift
@@ -30,7 +30,7 @@ internal struct ServiceKey {
 // MARK: Hashable
 extension ServiceKey: Hashable {
     var hashValue: Int {
-        return String(factoryType).hashValue ^ (name?.hashValue ?? 0) ^ (option?.hashValue ?? 0)
+        return String(describing: factoryType).hashValue ^ (name?.hashValue ?? 0) ^ (option?.hashValue ?? 0)
     }
 }
 

--- a/Sources/SpinLock.swift
+++ b/Sources/SpinLock.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 internal final class SpinLock {
-    private let lock = Lock()
+    private let lock =  NSLock()
     
-    func sync<T>(action: @noescape () -> T) -> T {
+    func sync<T>(action: () -> T) -> T {
         lock.lock()
         defer { lock.unlock() }
         return action()

--- a/Sources/SynchronizedResolver.Arguments.erb
+++ b/Sources/SynchronizedResolver.Arguments.erb
@@ -24,7 +24,7 @@ extension SynchronizedResolver {
 <%   arg_param_def = i == 1 ? "argument: Arg1" : "arguments arg1: Arg1, " + (2..i).map{ |n| "_ arg#{n}: Arg#{n}" }.join(", ") %>
 <%   arg_param_call = i == 1 ? "argument" : (1..i).map{ |n| "arg#{n}" }.join(", ") %>
     internal func resolve<Service, <%= arg_types %>>(
-        serviceType: Service.Type,
+        _ serviceType: Service.Type,
         <%= arg_param_def %>) -> Service?
     {
         return container.lock.sync {
@@ -33,7 +33,7 @@ extension SynchronizedResolver {
     }
 
     internal func resolve<Service, <%= arg_types %>>(
-        serviceType: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
         <%= arg_param_def %>) -> Service?
     {

--- a/Sources/SynchronizedResolver.Arguments.swift
+++ b/Sources/SynchronizedResolver.Arguments.swift
@@ -38,153 +38,153 @@ extension SynchronizedResolver {
 
     internal func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments)
+            return self.container.resolve(serviceType, arguments: arg1, arg2)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, arguments: arguments)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, arguments: arguments)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, arguments: arguments)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, arguments: arguments)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, arguments: arguments)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, arguments: arguments)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, arguments: arguments)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, arguments: arguments)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
     {
         return container.lock.sync {
-            return self.container.resolve(serviceType, name: name, arguments: arguments)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
         }
     }
 

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -833,7 +833,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Swinject Contributors";
 				TargetAttributes = {
 					981899BB1B5FE63F00C702D0 = {
@@ -1338,6 +1338,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 98AA74481BB70CBB00E2F48A /* Debug.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1357,6 +1359,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 98AA744A1BB70CBB00E2F48A /* Release.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-OSX.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-iOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-tvOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-watchOS.xcscheme
+++ b/Swinject.xcodeproj/xcshareddata/xcschemes/Swinject-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/AssemblerSpec.swift
+++ b/Tests/AssemblerSpec.swift
@@ -103,7 +103,7 @@ class AssemblerSpec: QuickSpec {
                 var cat = assembler.resolver.resolve(AnimalType.self)
                 expect(cat).to(beNil())
                 
-                assembler.applyAssembly(AnimalAssembly())
+                assembler.apply(assembly: AnimalAssembly())
                 
                 cat = assembler.resolver.resolve(AnimalType.self)
                 expect(cat).toNot(beNil())
@@ -122,7 +122,7 @@ class AssemblerSpec: QuickSpec {
                 }
                 
                 expect(loadAwareAssembly.loaded) == false
-                assembler.applyAssembly(loadAwareAssembly)
+                assembler.apply(assembly: loadAwareAssembly)
                 expect(loadAwareAssembly.loaded) == true
                 
                 cat = assembler.resolver.resolve(AnimalType.self)
@@ -138,7 +138,7 @@ class AssemblerSpec: QuickSpec {
                 var sushi = assembler.resolver.resolve(FoodType.self)
                 expect(sushi).to(beNil())
                 
-                assembler.applyAssembly(AnimalAssembly())
+                assembler.apply(assembly: AnimalAssembly())
                 
                 cat = assembler.resolver.resolve(AnimalType.self)
                 expect(cat).toNot(beNil())
@@ -147,7 +147,7 @@ class AssemblerSpec: QuickSpec {
                 sushi = assembler.resolver.resolve(FoodType.self)
                 expect(sushi).to(beNil())
                 
-                assembler.applyAssembly(FoodAssembly())
+                assembler.apply(assembly: FoodAssembly())
                 
                 sushi = assembler.resolver.resolve(FoodType.self)
                 expect(sushi).toNot(beNil())
@@ -161,7 +161,7 @@ class AssemblerSpec: QuickSpec {
                 var sushi = assembler.resolver.resolve(FoodType.self)
                 expect(sushi).to(beNil())
                 
-                assembler.applyAssemblies([
+                assembler.apply(assemblies: [
                     AnimalAssembly(),
                     FoodAssembly()
                 ])
@@ -227,7 +227,7 @@ class AssemblerSpec: QuickSpec {
                 var cat = assembler.resolver.resolve(AnimalType.self)
                 expect(cat).to(beNil())
                 
-                assembler.applyAssembly(AnimalAssembly())
+                assembler.apply(assembly: AnimalAssembly())
                 
                 cat = assembler.resolver.resolve(AnimalType.self)
                 expect(cat).toNot(beNil())

--- a/Tests/BasicAssembly.swift
+++ b/Tests/BasicAssembly.swift
@@ -10,7 +10,7 @@ import Swinject
 
 class AnimalAssembly: AssemblyType {
     
-    func assemble(_ container: Container) {
+    func assemble(container: Container) {
         container.register(AnimalType.self) { r in
             return Cat(name: "Whiskers")
         }
@@ -19,7 +19,7 @@ class AnimalAssembly: AssemblyType {
 
 class FoodAssembly: AssemblyType {
     
-    func assemble(_ container: Container) {
+    func assemble(container: Container) {
         container.register(FoodType.self) { r in
             return Sushi()
         }
@@ -28,7 +28,7 @@ class FoodAssembly: AssemblyType {
 
 class PersonAssembly: AssemblyType {
     
-    func assemble(_ container: Container) {
+    func assemble(container: Container) {
         container.register(PetOwner.self) { r in
             let definition = PetOwner()
             definition.favoriteFood = r.resolve(FoodType.self)

--- a/Tests/ContainerSpec.Circularity.swift
+++ b/Tests/ContainerSpec.Circularity.swift
@@ -39,9 +39,9 @@ class ContainerSpec_Circularity: QuickSpec {
                     expect(child.parent as? Parent) === parent
                 }
                 
-                runInObjectScope(.Graph)
-                runInObjectScope(.Container)
-                runInObjectScope(.Hierarchy)
+                runInObjectScope(.graph)
+                runInObjectScope(.container)
+                runInObjectScope(.hierarchy)
             }
             it("resolves circular dependency on the initializer and property.") {
                 let runInObjectScope: (ObjectScope) -> Void = { scope in
@@ -60,9 +60,9 @@ class ContainerSpec_Circularity: QuickSpec {
                     expect(child.parent as? Parent) === parent
                 }
                 
-                runInObjectScope(.Graph)
-                runInObjectScope(.Container)
-                runInObjectScope(.Hierarchy)
+                runInObjectScope(.graph)
+                runInObjectScope(.container)
+                runInObjectScope(.hierarchy)
             }
         }
         describe("More than two objects") {

--- a/Tests/ContainerSpec.Circularity.swift
+++ b/Tests/ContainerSpec.Circularity.swift
@@ -36,7 +36,7 @@ class ContainerSpec_Circularity: QuickSpec {
                     
                     let parent = container.resolve(ParentType.self) as! Parent
                     let child = parent.child as! Child
-                    expect(child.parent as? Parent) === parent
+                    expect(child.parent as? Parent === parent).to(beTrue()) // Workaround for crash in Nimble
                 }
                 
                 runInObjectScope(.graph)
@@ -57,7 +57,7 @@ class ContainerSpec_Circularity: QuickSpec {
                     
                     let parent = container.resolve(ParentType.self) as! Parent
                     let child = parent.child as! Child
-                    expect(child.parent as? Parent) === parent
+                    expect(child.parent as? Parent === parent).to(beTrue()) // Workaround for crash in Nimble
                 }
                 
                 runInObjectScope(.graph)
@@ -94,9 +94,9 @@ class ContainerSpec_Circularity: QuickSpec {
                 let b = a.b as! BDependingOnC
                 let c = b.c as! CDependingOnAD
                 let d = c.d as! DDependingOnBC
-                expect(c.a as? ADependingOnB) === a
-                expect(d.b as? BDependingOnC) === b
-                expect(d.c as? CDependingOnAD) === c
+                expect(c.a as? ADependingOnB === a).to(beTrue()) // Workaround for crash in Nimble
+                expect(d.b as? BDependingOnC === b).to(beTrue()) // Workaround for crash in Nimble
+                expect(d.c as? CDependingOnAD === c).to(beTrue()) // Workaround for crash in Nimble
             }
             it("resolves circular dependency on initializers and properties.") {
                 container.register(AType.self) { r in ADependingOnB(b: r.resolve(BType.self)!) }
@@ -117,9 +117,9 @@ class ContainerSpec_Circularity: QuickSpec {
                 let b = a.b as! BDependingOnC
                 let c = b.c as! CDependingOnAD
                 let d = c.d as! DDependingOnBC
-                expect(c.a as? ADependingOnB) === a
-                expect(d.b as? BDependingOnC) === b
-                expect(d.c as? CDependingOnAD) === c
+                expect(c.a as? ADependingOnB === a).to(beTrue()) // Workaround for crash in Nimble
+                expect(d.b as? BDependingOnC === b).to(beTrue()) // Workaround for crash in Nimble
+                expect(d.c as? CDependingOnAD === c).to(beTrue()) // Workaround for crash in Nimble
             }
         }
     }

--- a/Tests/ContainerSpec.swift
+++ b/Tests/ContainerSpec.swift
@@ -97,7 +97,7 @@ class ContainerSpec: QuickSpec {
             context("in no scope") {
                 it("does not have a shared object in a container.") {
                     container.register(AnimalType.self) { _ in Cat() }
-                        .inObjectScope(.None)
+                        .inObjectScope(.none)
                     
                     let cat1 = container.resolve(AnimalType.self) as! Cat
                     let cat2 = container.resolve(AnimalType.self) as! Cat
@@ -106,7 +106,7 @@ class ContainerSpec: QuickSpec {
                 it("resolves a service to new objects in a graph") {
                     registerCatAndPetOwnerDependingOnFood(container)
                     container.register(FoodType.self) { _ in Sushi() }
-                        .inObjectScope(.None)
+                        .inObjectScope(.none)
                     
                     let owner = container.resolve(PersonType.self) as! PetOwner
                     let ownersSushi = owner.favoriteFood as! Sushi
@@ -117,7 +117,7 @@ class ContainerSpec: QuickSpec {
             context("in graph scope") {
                 it("does not have a shared object in a container.") {
                     container.register(AnimalType.self) { _ in Cat() }
-                        .inObjectScope(.Graph)
+                        .inObjectScope(.graph)
                     
                     let cat1 = container.resolve(AnimalType.self) as! Cat
                     let cat2 = container.resolve(AnimalType.self) as! Cat
@@ -126,7 +126,7 @@ class ContainerSpec: QuickSpec {
                 it("resolves a service to the same object in a graph") {
                     registerCatAndPetOwnerDependingOnFood(container)
                     container.register(FoodType.self) { _ in Sushi() }
-                        .inObjectScope(.Graph)
+                        .inObjectScope(.graph)
                     
                     let owner = container.resolve(PersonType.self) as! PetOwner
                     let ownersSushi = owner.favoriteFood as! Sushi
@@ -137,7 +137,7 @@ class ContainerSpec: QuickSpec {
             context("in container scope") {
                 it("shares an object in the own container.") {
                     container.register(AnimalType.self) { _ in Cat() }
-                        .inObjectScope(.Container)
+                        .inObjectScope(.container)
                     
                     let cat1 = container.resolve(AnimalType.self) as! Cat
                     let cat2 = container.resolve(AnimalType.self) as! Cat
@@ -146,9 +146,9 @@ class ContainerSpec: QuickSpec {
                 it("does not share an object from a parent container to its child.") {
                     let parent = Container()
                     parent.register(AnimalType.self) { _ in Cat() }
-                        .inObjectScope(.Container)
+                        .inObjectScope(.container)
                     parent.register(AnimalType.self, name: "dog") { _ in Dog() }
-                        .inObjectScope(.Container)
+                        .inObjectScope(.container)
                     let child = Container(parent: parent)
                     
                     // Case resolving on the parent first.
@@ -164,7 +164,7 @@ class ContainerSpec: QuickSpec {
                 it("resolves a service to the same object in a graph") {
                     registerCatAndPetOwnerDependingOnFood(container)
                     container.register(FoodType.self) { _ in Sushi() }
-                        .inObjectScope(.Container)
+                        .inObjectScope(.container)
                     
                     let owner = container.resolve(PersonType.self) as! PetOwner
                     let ownersSushi = owner.favoriteFood as! Sushi
@@ -175,7 +175,7 @@ class ContainerSpec: QuickSpec {
             context("in hierarchy scope") {
                 it("shares an object in the own container.") {
                     container.register(AnimalType.self) { _ in Cat() }
-                        .inObjectScope(.Hierarchy)
+                        .inObjectScope(.hierarchy)
                     
                     let cat1 = container.resolve(AnimalType.self) as! Cat
                     let cat2 = container.resolve(AnimalType.self) as! Cat
@@ -184,9 +184,9 @@ class ContainerSpec: QuickSpec {
                 it("shares an object from a parent container to its child.") {
                     let parent = Container()
                     parent.register(AnimalType.self) { _ in Cat() }
-                        .inObjectScope(.Hierarchy)
+                        .inObjectScope(.hierarchy)
                     parent.register(AnimalType.self, name: "dog") { _ in Dog() }
-                        .inObjectScope(.Hierarchy)
+                        .inObjectScope(.hierarchy)
                     let child = Container(parent: parent)
                     
                     // Case resolving on the parent first.
@@ -202,7 +202,7 @@ class ContainerSpec: QuickSpec {
                 it("resolves a service in the parent container to the same object in a graph") {
                     let parent = Container()
                     parent.register(FoodType.self) { _ in Sushi() }
-                        .inObjectScope(.Hierarchy)
+                        .inObjectScope(.hierarchy)
                     let child = Container(parent: parent)
                     registerCatAndPetOwnerDependingOnFood(child)
                     
@@ -290,10 +290,10 @@ class ContainerSpec: QuickSpec {
                     expect(turtle2.name) == "Ninja"
                 }
                 
-                runInObjectScope(.None)
-                runInObjectScope(.Graph)
-                runInObjectScope(.Container)
-                runInObjectScope(.Hierarchy)
+                runInObjectScope(.none)
+                runInObjectScope(.graph)
+                runInObjectScope(.container)
+                runInObjectScope(.hierarchy)
             }
             it("resolves struct instances defined in the parent container ignoring object scopes.") {
                 let runInObjectScope: (ObjectScope) -> Void = { scope in
@@ -309,10 +309,10 @@ class ContainerSpec: QuickSpec {
                     expect(turtle2.name) == "Ninja"
                 }
                 
-                runInObjectScope(.None)
-                runInObjectScope(.Graph)
-                runInObjectScope(.Container)
-                runInObjectScope(.Hierarchy)
+                runInObjectScope(.none)
+                runInObjectScope(.graph)
+                runInObjectScope(.container)
+                runInObjectScope(.hierarchy)
             }
         }
         describe("Class as a service type") {
@@ -371,7 +371,7 @@ class ContainerSpec: QuickSpec {
             }
             it("describes a registration with a specified object scope.") {
                 container.register(AnimalType.self) { _ in Cat() }
-                    .inObjectScope(.Container)
+                    .inObjectScope(.container)
                 
                 expect(container.description) ==
                     "[\n"

--- a/Tests/ContainerSpec.swift
+++ b/Tests/ContainerSpec.swift
@@ -101,7 +101,7 @@ class ContainerSpec: QuickSpec {
                     
                     let cat1 = container.resolve(AnimalType.self) as! Cat
                     let cat2 = container.resolve(AnimalType.self) as! Cat
-                    expect(cat1) !== cat2
+                    expect(cat1 !== cat2).to(beTrue()) // Workaround for crash in Nimble.
                 }
                 it("resolves a service to new objects in a graph") {
                     registerCatAndPetOwnerDependingOnFood(container)
@@ -111,7 +111,7 @@ class ContainerSpec: QuickSpec {
                     let owner = container.resolve(PersonType.self) as! PetOwner
                     let ownersSushi = owner.favoriteFood as! Sushi
                     let catsSushi = (owner.pet as! Cat).favoriteFood as! Sushi
-                    expect(ownersSushi) !== catsSushi
+                    expect(ownersSushi !== catsSushi).to(beTrue()) // Workaround for crash in Nimble.
                 }
             }
             context("in graph scope") {
@@ -121,7 +121,7 @@ class ContainerSpec: QuickSpec {
                     
                     let cat1 = container.resolve(AnimalType.self) as! Cat
                     let cat2 = container.resolve(AnimalType.self) as! Cat
-                    expect(cat1) !== cat2
+                    expect(cat1 !== cat2).to(beTrue()) // Workaround for crash in Nimble.
                 }
                 it("resolves a service to the same object in a graph") {
                     registerCatAndPetOwnerDependingOnFood(container)
@@ -131,7 +131,7 @@ class ContainerSpec: QuickSpec {
                     let owner = container.resolve(PersonType.self) as! PetOwner
                     let ownersSushi = owner.favoriteFood as! Sushi
                     let catsSushi = (owner.pet as! Cat).favoriteFood as! Sushi
-                    expect(ownersSushi) === catsSushi
+                    expect(ownersSushi === catsSushi).to(beTrue()) // Workaround for crash in Nimble.
                 }
             }
             context("in container scope") {
@@ -141,7 +141,7 @@ class ContainerSpec: QuickSpec {
                     
                     let cat1 = container.resolve(AnimalType.self) as! Cat
                     let cat2 = container.resolve(AnimalType.self) as! Cat
-                    expect(cat1) === cat2
+                    expect(cat1 === cat2).to(beTrue()) // Workaround for crash in Nimble.
                 }
                 it("does not share an object from a parent container to its child.") {
                     let parent = Container()
@@ -154,12 +154,12 @@ class ContainerSpec: QuickSpec {
                     // Case resolving on the parent first.
                     let cat1 = parent.resolve(AnimalType.self) as! Cat
                     let cat2 = child.resolve(AnimalType.self) as! Cat
-                    expect(cat1) !== cat2
+                    expect(cat1 !== cat2).to(beTrue()) // Workaround for crash in Nimble.
                     
                     // Case resolving on the child first.
                     let dog1 = child.resolve(AnimalType.self, name: "dog") as! Dog
                     let dog2 = parent.resolve(AnimalType.self, name: "dog") as! Dog
-                    expect(dog1) !== dog2
+                    expect(dog1 !== dog2).to(beTrue()) // Workaround for crash in Nimble.
                 }
                 it("resolves a service to the same object in a graph") {
                     registerCatAndPetOwnerDependingOnFood(container)
@@ -169,7 +169,7 @@ class ContainerSpec: QuickSpec {
                     let owner = container.resolve(PersonType.self) as! PetOwner
                     let ownersSushi = owner.favoriteFood as! Sushi
                     let catsSushi = (owner.pet as! Cat).favoriteFood as! Sushi
-                    expect(ownersSushi) === catsSushi
+                    expect(ownersSushi === catsSushi).to(beTrue()) // Workaround for crash in Nimble.
                 }
             }
             context("in hierarchy scope") {
@@ -179,7 +179,7 @@ class ContainerSpec: QuickSpec {
                     
                     let cat1 = container.resolve(AnimalType.self) as! Cat
                     let cat2 = container.resolve(AnimalType.self) as! Cat
-                    expect(cat1) === cat2
+                    expect(cat1 === cat2).to(beTrue()) // Workaround for crash in Nimble.
                 }
                 it("shares an object from a parent container to its child.") {
                     let parent = Container()
@@ -192,12 +192,12 @@ class ContainerSpec: QuickSpec {
                     // Case resolving on the parent first.
                     let cat1 = parent.resolve(AnimalType.self) as! Cat
                     let cat2 = child.resolve(AnimalType.self) as! Cat
-                    expect(cat1) === cat2
+                    expect(cat1 === cat2).to(beTrue()) // Workaround for crash in Nimble.
                     
                     // Case resolving on the child first.
                     let dog1 = child.resolve(AnimalType.self, name: "dog") as! Dog
                     let dog2 = parent.resolve(AnimalType.self, name: "dog") as! Dog
-                    expect(dog1) === dog2
+                    expect(dog1 === dog2).to(beTrue()) // Workaround for crash in Nimble.
                 }
                 it("resolves a service in the parent container to the same object in a graph") {
                     let parent = Container()
@@ -209,7 +209,7 @@ class ContainerSpec: QuickSpec {
                     let owner = child.resolve(PersonType.self) as! PetOwner
                     let ownersSushi = owner.favoriteFood as! Sushi
                     let catsSushi = (owner.pet as! Cat).favoriteFood as! Sushi
-                    expect(ownersSushi) === catsSushi
+                    expect(ownersSushi === catsSushi).to(beTrue()) // Workaround for crash in Nimble.
                 }
             }
         }

--- a/Tests/LoadAwareAssembly.swift
+++ b/Tests/LoadAwareAssembly.swift
@@ -13,11 +13,11 @@ class LoadAwareAssembly: AssemblyType {
     var onLoad: (ResolverType) -> Void
     var loaded = false
     
-    init(onLoad: (ResolverType) -> Void) {
+    init(onLoad: @escaping (ResolverType) -> Void) {
         self.onLoad = onLoad
     }
     
-    func assemble(_ container: Container) {
+    func assemble(container: Container) {
         container.register(AnimalType.self) { r in
             return Cat(name: "Bojangles")
         }

--- a/Tests/ServiceEntrySpec.swift
+++ b/Tests/ServiceEntrySpec.swift
@@ -12,9 +12,9 @@ import Nimble
 
 class ServiceEntrySpec: QuickSpec {
     override func spec() {
-        it("has ObjectScope.Graph as a default value of scope property.") {
+        it("has ObjectScope.graph as a default value of scope property.") {
             let entry = ServiceEntry(serviceType: Int.self, factory: { return 0 })
-            expect(entry.objectScope) == ObjectScope.Graph
+            expect(entry.objectScope) == ObjectScope.graph
         }
     }
 }

--- a/Tests/SynchronizedResolverSpec.swift
+++ b/Tests/SynchronizedResolverSpec.swift
@@ -99,6 +99,7 @@ class SynchronizedResolverSpec: QuickSpec {
             self.max = max
         }
         
+        @discardableResult
         func increment() -> Status {
             var status = Status.underMax
             lock.sync {

--- a/Tests/SynchronizedResolverSpec.swift
+++ b/Tests/SynchronizedResolverSpec.swift
@@ -37,7 +37,7 @@ class SynchronizedResolverSpec: QuickSpec {
                         queue.async() {
                             let parent = container.resolve(ParentType.self) as! Parent
                             let child = parent.child as! Child
-                            expect(child.parent as? Parent) === parent
+                            expect(child.parent as? Parent === parent).to(beTrue()) // Workaround for crash in Nimble
                             
                             counter.increment()
                             if counter.count >= totalThreads {


### PR DESCRIPTION
Main changes:

- Support Xcode 8 beta 6.
- Update Quick and Nimble to specific commits to run with Xcode 8 beta 6.
- Fix uint tests for Xcode 8 beta 6. Still some tests fail.
- Add `@discardableResult` to suppress warnings.